### PR TITLE
Allow Math.min and Math.max intrinsics.

### DIFF
--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -24,6 +24,12 @@ describe "Math" do
   describe "Order-related functions" do
     Math.min(2.1, 2.11).should eq(2.1)
     Math.max(3.2, 3.11).should eq(3.2)
+
+    Math.min(2.1_f32, 2.11_f32).should eq(2.1_f32)
+    Math.max(3.2_f32, 3.11_f32).should eq(3.2_f32)
+
+    Math.min(210, 211).should eq(210)
+    Math.max(320, 311).should eq(320)
   end
 
   pending "Functions for computing quotient and remainder" do

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -31,11 +31,10 @@ lib LibM
   fun log2_f64 = "llvm.log2.f64"(value : Float64) : Float64
   fun log10_f32 = "llvm.log10.f32"(value : Float32) : Float32
   fun log10_f64 = "llvm.log10.f64"(value : Float64) : Float64
-  # ## To be uncommented once LLVM is updated
-  # fun min_f32 = "llvm.minnum.f32"(value1 : Float32, value2 : Float32) : Float32
-  # fun min_f64 = "llvm.minnum.f64"(value1 : Float64, value2 : Float64) : Float64
-  # fun max_f32 = "llvm.maxnum.f32"(value1 : Float32, value2 : Float32) : Float32
-  # fun max_f64 = "llvm.maxnum.f64"(value1 : Float64, value2 : Float64) : Float64
+  fun min_f32 = "llvm.minnum.f32"(value1 : Float32, value2 : Float32) : Float32
+  fun min_f64 = "llvm.minnum.f64"(value1 : Float64, value2 : Float64) : Float64
+  fun max_f32 = "llvm.maxnum.f32"(value1 : Float32, value2 : Float32) : Float32
+  fun max_f64 = "llvm.maxnum.f64"(value1 : Float64, value2 : Float64) : Float64
   fun pow_f32 = "llvm.pow.f32"(value : Float32, power : Float32) : Float32
   fun pow_f64 = "llvm.pow.f64"(value : Float64, power : Float64) : Float64
   fun powi_f32 = "llvm.powi.f32"(value : Float32, power : Int32) : Float32

--- a/src/math/math.cr
+++ b/src/math/math.cr
@@ -131,28 +131,28 @@ module Math
     log(numeric) / log(base)
   end
 
-  # ## To be uncommented once LLVM is updated
-  # def max(value1 : Float32, value2 : Float32)
-  #   LibM.max_f32(value1, value2)
-  # end
-  #
-  # def max(value1 : Float64, value2 : Float64)
-  #   LibM.max_f64(value1, value2)
-  # end
+  def max(value1 : Float32, value2 : Float32)
+    LibM.max_f32(value1, value2)
+  end
+
+  def max(value1 : Float64, value2 : Float64)
+    LibM.max_f64(value1, value2)
+  end
 
   # Returns the greater of *value1* and *value2*.
   def max(value1, value2)
     value1 >= value2 ? value1 : value2
   end
 
-  # ## To be uncommented once LLVM is updated
-  # def min(value1 : Float32, value2 : Float32)
-  #  LibM.min_f32(value1, value2)
-  # end
-  #
-  # def min(value1 : Float64, value2 : Float64)
-  #  LibM.min_f64(value1, value2)
-  # end
+  # Returns the smaller of *value1* and *value2*.
+  def min(value1 : Float32, value2 : Float32)
+    LibM.min_f32(value1, value2)
+  end
+
+  # Returns the smaller of *value1* and *value2*.
+  def min(value1 : Float64, value2 : Float64)
+    LibM.min_f64(value1, value2)
+  end
 
   # Returns the smaller of *value1* and *value2*.
   def min(value1, value2)


### PR DESCRIPTION
It works fine with LLVM 3.6+, just tested with LLVM 3.9 and 4.0. LLVM 3.7 doesn't compatible with Crystal compiler (but runtime is compatible).
 
Extracted from #4559.