### PR TITLE
Add spec for annotations on alias

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -204,6 +204,19 @@ describe Doc::Generator do
           doc_method.formatted_doc.should eq %(<p>Some Method</p>\n<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>)
         end
       end
+
+      describe "with alias" do
+        it "should generate the #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
+
+          alias_type = AliasType.new(program, program, "Foo", Crystal::Path.new("Bar"))
+          alias_type.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          doc_type = Doc::Type.new generator, alias_type
+          doc_type.formatted_doc.should eq %(<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>)
+        end
+      end
     end
 
     describe "with no annotation, and no docs" do


### PR DESCRIPTION
Annotations on aliases already work implicitly on the base branch. This patch just adds a spec for that.